### PR TITLE
fix: handle wallet partner keys in swaps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kaspacom/swap-sdk",
-  "version": "1.1.26",
+  "version": "1.1.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kaspacom/swap-sdk",
-      "version": "1.1.26",
+      "version": "1.1.28",
       "license": "MIT",
       "dependencies": {
         "@uniswap/sdk-core": "^7.7.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaspacom/swap-sdk",
-  "version": "1.1.26",
+  "version": "1.1.28",
   "type": "module",
   "description": "A lightweight swap sdk for Kaspa DeFi that can be embedded in wallets or websites",
   "main": "dist/index.cjs",

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -1,6 +1,34 @@
 import { ethers } from "ethers";
 import { SwapSdkNetworkConfig } from "../types";
 
+const IGRA_MAINNET_CONFIG: SwapSdkNetworkConfig = {
+  name: 'Igra',
+  chainId: 38833,
+  rpcUrl: 'https://rpc.igralabs.com:8545',
+  routerAddress: '0x771dfB21e1CD8EA3e8B68cB2469eDaF9548c2523',
+  factoryAddress: '0x21350BcDa9E81731CF4cDE3DbC457e3de2739c01',
+  proxyAddress: '0xDD1aBB133D027f4F67571b5bEEDC9cd9a93C13Ca',
+  badckendApiUrl: 'https://api-defi.kaspa.com',
+  blockExplorerUrl: 'https://explorer.igralabs.com',
+  additionalJsonRpcApiProviderOptionsOptions: {
+    batchMaxSize: 0,
+  },
+  wrappedToken: {
+    address: '0x17Ec7E1768c813E2a3a9b0f94A35605CA520C242',
+    decimals: 18,
+    name: 'Igra Wrapped Kaspa',
+    symbol: 'IWKAS',
+  },
+  nativeToken: {
+    address: ethers.ZeroAddress,
+    decimals: 18,
+    name: 'Igra Kaspa',
+    symbol: 'IKAS',
+  },
+  isTestnet: false,
+  defiApiNetworkName: 'igra',
+};
+
 export const NETWORKS: Record<string, SwapSdkNetworkConfig> = {
   'kasplex-testnet': {
     name: 'Kasplex Test',
@@ -86,32 +114,7 @@ export const NETWORKS: Record<string, SwapSdkNetworkConfig> = {
     },
     defiApiNetworkName: 'kasplex',
   },
-  'igra': {
-    name: 'Igra',
-    chainId: 38833,
-    rpcUrl: 'https://rpc.igralabs.com:8545',
-    routerAddress: '0x771dfB21e1CD8EA3e8B68cB2469eDaF9548c2523',
-    factoryAddress: '0x21350BcDa9E81731CF4cDE3DbC457e3de2739c01',
-    proxyAddress: '0xDD1aBB133D027f4F67571b5bEEDC9cd9a93C13Ca',
-    badckendApiUrl: 'https://api-defi.kaspa.com',
-    blockExplorerUrl: 'https://explorer.igralabs.com',
-    additionalJsonRpcApiProviderOptionsOptions: {
-      batchMaxSize: 0,
-    },
-    wrappedToken: {
-      address: '0x17Ec7E1768c813E2a3a9b0f94A35605CA520C242',
-      decimals: 18,
-      name: 'Igra Wrapped Kaspa',
-      symbol: 'IWKAS',
-    },
-    nativeToken: {
-      address: ethers.ZeroAddress,
-      decimals: 18,
-      name: 'Igra Kaspa',
-      symbol: 'IKAS',
-    },
-    isTestnet: false,
-    defiApiNetworkName: 'igra',
-  },
+  'igra': IGRA_MAINNET_CONFIG,
+  'igra-mainnet': IGRA_MAINNET_CONFIG,
   // Add more networks as needed
-}; 
+};

--- a/src/controllers/swap-sdk.controller.ts
+++ b/src/controllers/swap-sdk.controller.ts
@@ -7,12 +7,17 @@ import {
   SwapControllerInput,
   LoaderStatuses,
   SwapSdkNetworkConfig,
+  ComputedAmounts,
 } from '../types';
 import { Eip1193Provider } from 'ethers';
 
 export const DEFAULT_SETTINGS: SwapSettings = {
   maxSlippage: '0.5',
   swapDeadline: 20,
+}
+
+function getApprovalAmountRaw(computed: ComputedAmounts): string {
+  return computed.maxAmountInRaw || computed.amountInRaw;
 }
 
 export class SwapSdkController {
@@ -142,7 +147,7 @@ export class SwapSdkController {
     if (!this.input || !this.walletService!.isConnected() || !this.swapService) throw new Error('Wallet not connected or input missing');
     const { fromToken, amount } = this.input;
     if (!fromToken || amount === undefined || !this.state.computed?.amountInRaw) throw new Error('fromToken or amount missing');
-    return (await this.swapService!.isApprovalNeeded(fromToken, BigInt(this.state.computed.amountInRaw))).isApprovalNeeded;
+    return (await this.swapService!.isApprovalNeeded(fromToken, BigInt(getApprovalAmountRaw(this.state.computed)))).isApprovalNeeded;
   }
 
   async approveIfNeeded(): Promise<string | undefined> {
@@ -155,7 +160,7 @@ export class SwapSdkController {
     try {
       const tx = await this.swapService?.approveIfNeedApproval(
         fromToken,
-        BigInt(this.state.computed.amountInRaw),
+        BigInt(getApprovalAmountRaw(this.state.computed)),
       )
 
       let receipt;

--- a/src/services/swap.service.ts
+++ b/src/services/swap.service.ts
@@ -113,8 +113,9 @@ export class SwapService {
       return this.partnerFee;
     }
     try {
-      if (this.swapOptions.partnerKey && this.proxyContract) {
-        const [, fee] = await this.proxyContract?.partners(this.swapOptions.partnerKey);
+      const partnerKey = this.normalizePartnerKey(this.swapOptions.partnerKey);
+      if (partnerKey && this.proxyContract) {
+        const [, fee] = await this.proxyContract?.partners(partnerKey);
         this.partnerFee = fee;
       }
 
@@ -774,6 +775,22 @@ export class SwapService {
 
 
 
+  private normalizePartnerKey(partnerKey?: string): string | undefined {
+    const trimmed = partnerKey?.trim();
+    if (!trimmed) return undefined;
+
+    if (/^0x[0-9a-fA-F]{64}$/.test(trimmed)) {
+      return trimmed;
+    }
+
+    const utf8Bytes = ethers.toUtf8Bytes(trimmed);
+    if (utf8Bytes.length > 32) {
+      throw new Error('partnerKey must be a bytes32 hex string or UTF-8 text up to 32 bytes');
+    }
+
+    return ethers.hexlify(ethers.zeroPadBytes(utf8Bytes, 32));
+  }
+
   /**
    * Concatenates bytes: selector, array of bytes (each element is Uint8Array), array length (uint8, 1 byte), marker (bytes16(keccak256(markerString)))
    * @param selectorBytes Uint8Array — function selector (usually 4 bytes)
@@ -811,7 +828,7 @@ export class SwapService {
     ];
 
     if (partnerKey) {
-      const partnerKeyBytes = ethers.getBytes(partnerKey); // 32 bytes
+      const partnerKeyBytes = ethers.getBytes(this.normalizePartnerKey(partnerKey)!); // 32 bytes
       const partnerFlagHash = ethers.keccak256(ethers.toUtf8Bytes("PARTNER"));
       const partnerFlagBytes = ethers.getBytes(partnerFlagHash).slice(0, 16); // 16 bytes
       parts.push(partnerKeyBytes, partnerFlagBytes);


### PR DESCRIPTION
## Summary
- normalize text partner keys (e.g. `kaspacom`) into bytes32 before reading partner fees or suffixing proxy calldata
- keep PARTNER suffix in proxy calldata for text partner keys
- use `maxAmountInRaw || amountInRaw` for ERC20 exact-output approval checks
- add `igra-mainnet` as an alias for the Igra mainnet SDK config
- bump package version to `1.1.28`

## Verification
- `npm ci`
- `npm run build`
- local dist smoke check confirmed `partnerKey: 'kaspacom'` normalizes to `0x6b61737061636f6d000000000000000000000000000000000000000000000000` and calldata includes both PERMIT + PARTNER markers

## Notes
- `npm ci` reports existing dependency audit findings: 11 vulnerabilities (1 low, 3 moderate, 7 high). No dependency changes were made besides package version metadata.